### PR TITLE
Problem: Dangling submodule reference (unused) in t-b-p

### DIFF
--- a/pins/tezos-baking-platform/default.nix
+++ b/pins/tezos-baking-platform/default.nix
@@ -1,5 +1,5 @@
 (import <nixpkgs> {}).fetchgit {
   url = "https://gitlab.com/clacke/tezos-baking-platform";
-  rev = "cd102cc83edc456a62b0daa8c48c5ad92c4eca05";
-  sha256 = "1366mqfjbigr916lrw9yiaf9lnw8pgdx4k6qsggqcn8093c0s8l1";
+  rev = "bd00a77315fca9ef3a52012b74c34592a87cb1ae";
+  sha256 = "02zhjx7x16f3qiln22d4dkjwwdwyn1yvjn24608l4ahhi3dnsjrs";
 }


### PR DESCRIPTION
    fatal: No url found for submodule path 'ledger/nanos-secure-sdk' in .gitmodules

Solution: Bump to tezos-baking-platform with this removed.

Lesson learned: Modify .gitmodules with `git rm <reference>` when
possible (when the reference exists), rather than editing
.gitmodules, to not forget removing the reference later.

But this is also an example of why submodules are best avoided to
begin with. Too many moving parts, too brittle.