### PR TITLE
Problem: stakepool.nix: Cannot import without configuring

### DIFF
--- a/modules/stakepool.nix
+++ b/modules/stakepool.nix
@@ -43,6 +43,7 @@ in
 {
   options = {
     services.tezos.nodes = mkOption {
+      default = [];
       type = types.listOf tezosNode;
       description = "List of Tezos nodes";
     };


### PR DESCRIPTION
If you add `stakepool.nix` to imports, you need to define
`services.tezos.nodes`, or you'll get:

    error: The option 'services.tezos.nodes' is used but not defined.

Solution: Provide a default.