### PR TITLE
Problem: Not caching for people running on NixOS channels

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -6,6 +6,9 @@ let
     inherit (import path { configuration = ./stub-system/configuration.nix; }) system;
   };
 in
-genJobs <nixpkgs/nixos> // (import <nixpkgs> {}).lib.optionalAttrs isTravis {
+genJobs <nixpkgs/nixos> // {
+  oldstable = genJobs <nixos-oldstable/nixos>;
+  stable = genJobs <nixos-stable/nixos>;
+} // (import <nixpkgs> {}).lib.optionalAttrs isTravis {
   travisOrder = [ "system" ];
 }


### PR DESCRIPTION
Solution: Build for nixos-oldstable and nixos-stable.

On hydra these are currently configured for nixos-18.03 and
nixos-18.09.