### PR TITLE
 Problem: ./release.sh does not work on default NixOS

### DIFF
--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -24,7 +24,7 @@ function main() {
 function build() {
   local nixpkgs_paths=()
   if local nixpkgs_path=$(nix-instantiate --eval -E 'builtins.toString <nixpkgs>'); then
-    nixpkgs_paths+=( -I nixpkgs="$(eval "readlink $nixpkgs_path")" )
+    nixpkgs_paths+=( -I nixpkgs="$(eval "readlink -e $nixpkgs_path")" )
   fi
 
   nix-build --fallback --option restrict-eval true --arg isTravis true \

--- a/support/utils/nix-build-travis-fold.sh
+++ b/support/utils/nix-build-travis-fold.sh
@@ -23,14 +23,9 @@ function main() {
 
 function build() {
   local nixpkgs_paths=()
-
-  for path in \
-    $HOME/.nix-defexpr/channels/nixpkgs \
-    /nix/var/nix/profiles/per-user/root/channels/nixpkgs \
-  ; do
-    [[ -e $path ]] &&
-    nixpkgs_paths+=(-I "$(readlink "$path")")
-  done
+  if local nixpkgs_path=$(nix-instantiate --eval -E 'builtins.toString <nixpkgs>'); then
+    nixpkgs_paths+=( -I nixpkgs="$(eval "readlink $nixpkgs_path")" )
+  fi
 
   nix-build --fallback --option restrict-eval true --arg isTravis true \
     "${nixpkgs_paths[@]}" \


### PR DESCRIPTION


It breaks if your nixpkgs is not in `~/.nix-defexpr/channels/nixpkgs`,
e.g. if you have a `NIX_PATH=nixpkgs=.../root/channels/nixos/nixpkgs`,
which NixOS has by default.

Solution: Take the updated solution from fractalide/racket2nix#170 .

 - Evaluate <nixpkgs> instead of guessing.
 - Canonicalize link path (`readlink -e ...`).