### PR TITLE
Problem: Hydra cannot evaluate release.nix

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -2,15 +2,24 @@
 }:
 
 let
-  genJobs = nixpkgsPath: let pkgs = import nixpkgsPath {}; in {
-    inherit (import "${nixpkgsPath}/nixos" {
-      configuration = import ./stub-system/configuration.nix { inherit pkgs; };}) system;
-  };
+  genJobs = nixpkgs: nixos: let
+    pkgs = import nixpkgs {};
+    os = import nixos { configuration = import ./stub-system/configuration.nix { inherit pkgs; }; };
+  in
+    { inherit (os) system; };
+  pinnedNixpkgs = import ./pins/nixpkgs;
+  pinnedNixos = (import pinnedNixpkgs {}).runCommand "nixos" { inherit pinnedNixpkgs; } ''
+    mkdir $out
+    ln -s $pinnedNixpkgs $out/nixpkgs
+    cat >$out/default.nix <<EOF
+      { configuration }: import ./nixpkgs/nixos { inherit configuration; }
+    EOF
+  '';
 in
-genJobs (import ./pins/nixpkgs) // {
-  unstable = genJobs <nixpkgs>;
-  oldstable = genJobs <nixos-oldstable>;
-  stable = genJobs <nixos-stable>;
+genJobs pinnedNixpkgs pinnedNixos // {
+  unstable = genJobs <nixpkgs> <nixpkgs/nixos>;
+  oldstable = genJobs <nixos-oldstable> <nixos-oldstable/nixos>;
+  stable = genJobs <nixos-stable> <nixos-stable/nixos>;
 } // (import <nixpkgs> {}).lib.optionalAttrs isTravis {
   travisOrder = [ "system" ];
 }


### PR DESCRIPTION
```
Oct 02 16:32:50 mail.fractalide.com hydra-evaluator[21368]: starting evaluation of jobset ‘fractalide:tezos-stakepool’ (last checked 600 s ago)
Oct 02 16:33:21 mail.fractalide.com hydra-evaluator[21368]: received jobset event
Oct 02 16:33:22 mail.fractalide.com hydra-evaluator[21368]: hydra-eval-jobs returned exit code 1:
Oct 02 16:33:22 mail.fractalide.com hydra-evaluator[21368]: error: access to path '/nix/store/9445svhcspwaadrm26v2raclw3x4ayc9-q9nhs2f1lpzhmy6knagrahnyviypnvgr-git-export/nixos' is forbidden in restricted mode
Oct 02 16:33:22 mail.fractalide.com hydra-evaluator[21368]: evaluation of jobset ‘fractalide:tezos-stakepool’ failed with exit code 1
```

It worked fine when we referred to <nixpkgs/nixos> etc, so let's go
back to doing that for those paths, but now with a reference to
<nixpkgs> etc as well. For the pinned nixpkgs we'll need something
else, a wrapper that can call the `nixos` directory for us, with a
relative path.

Solution: Remove path manipulation, replace with a wrapper.

Cannot reproduce the restriction outside hydra-evaluator, so let's
merge this and see what it does for #14.