### PR TITLE
Problem: No nixos-unstable

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -20,6 +20,7 @@ genJobs pinnedNixpkgs pinnedNixos // {
   unstable = genJobs <nixpkgs> <nixpkgs/nixos>;
   oldstable = genJobs <nixos-oldstable> <nixos-oldstable/nixos>;
   stable = genJobs <nixos-stable> <nixos-stable/nixos>;
+  nixos-unstable = genJobs <nixos-unstable> <nixos-unstable/nixos>;
 } // (import <nixpkgs> {}).lib.optionalAttrs isTravis {
   travisOrder = [ "system" ];
 }


### PR DESCRIPTION
I expect some people might be running this, so we might as well
support it. Probably not a huge cost, as it should have a lot of
overlap with nixpkgs-unstable.

Hydra has already been configured to support it.