### PR TITLE
 Problem: No baker services

### DIFF
--- a/modules/stakepool.nix
+++ b/modules/stakepool.nix
@@ -14,6 +14,15 @@ let
         types.enum (builtins.attrNames tezos-baking-platform.tezos);
       description = "Which tezos network to run on";
     };
+    bakerAddressAlias = mkOption {
+      default = "baker";
+      type = types.str;
+      description = "The alias of the implicit address used by the baker.";
+    };
+    bakerDir = mkOption {
+      type = types.str;
+      description = "Where to store baker state.";
+    };
     configDir = mkOption {
       type = types.str;
       description = "Where to store node state, e.g. identity secret, entire blockchain.";
@@ -49,7 +58,8 @@ let
       description = "Tezos ${current.network} initialization";
       script = import ./tezos-init.sh.nix {
         inherit (tezos-baking-platform.tezos."${current.network}") kit;
-        inherit (current) configDir user;
+        inherit (current) bakerAddressAlias bakerDir configDir user;
+        baking = current.baking.enable;
         inherit (pkgs) runit;
       };
       after = [ "local-fs.target" ];
@@ -72,10 +82,53 @@ let
       wants = [ "${init-name}.service" ];
       serviceConfig.User = current.user;
     };
+    accuser-name = "tezos-${current.network}-accuser-${toString index}";
+    accuser-value = {
+      description = "Tezos ${current.network} accuser";
+      script = import ./tezos-accuser.sh.nix {
+        inherit (tezos-baking-platform.tezos."${current.network}") kit;
+        inherit index;
+        inherit (current) bakerDir;
+      };
+      wantedBy = [ "multi-user.target" ];
+      after = [ "${run-name}.service" ];
+      wants = [ "${run-name}.service" ];
+      serviceConfig.User = current.user;
+    };
+    baker-name = "tezos-${current.network}-baker-${toString index}";
+    baker-value = {
+      description = "Tezos ${current.network} baker";
+      script = import ./tezos-baker.sh.nix {
+        inherit (tezos-baking-platform.tezos."${current.network}") kit;
+        inherit index;
+        inherit (current) bakerAddressAlias bakerDir configDir;
+      };
+      wantedBy = [ "multi-user.target" ];
+      after = [ "${run-name}.service" ];
+      wants = [ "${run-name}.service" ];
+      serviceConfig.User = current.user;
+    };
+    endorser-name = "tezos-${current.network}-endorser-${toString index}";
+    endorser-value = {
+      description = "Tezos ${current.network} endorser";
+      script = import ./tezos-endorser.sh.nix {
+        inherit (tezos-baking-platform.tezos."${current.network}") kit;
+        inherit index;
+        inherit (current) bakerAddressAlias bakerDir;
+      };
+      wantedBy = [ "multi-user.target" ];
+      after = [ "${run-name}.service" ];
+      wants = [ "${run-name}.service" ];
+      serviceConfig.User = current.user;
+    };
   in
     makeServiceEntries (index + 1) (builtins.tail nodes) (done // {
       "${init-name}" = init-value;
       "${run-name}" = run-value;
+    } // lib.optionalAttrs current.baking.enable {
+      "${accuser-name}" = accuser-value;
+      "${baker-name}" = baker-value;
+      "${endorser-name}" = endorser-value;
     });
 in
 {
@@ -98,7 +151,7 @@ in
     };
 
     assertions = [
-      { assertion = all (node: node.pkgs.stdenv.isLinux) cfg.nodes; message = "Service only defined for Linux systems."; }
+      { assertion = all (node: node.pkgs.stdenv.isLinux) cfg.nodes; message = "Services defined only for Linux systems."; }
     ];
   };
 }

--- a/modules/tezos-accuser.sh.nix
+++ b/modules/tezos-accuser.sh.nix
@@ -1,0 +1,13 @@
+{ bakerDir
+, index
+, kit
+}:
+
+''
+set -e
+set -u
+set -o pipefail
+
+exec ${kit}/bin/tezos-accuser-002-PsYLVpVv --base-dir "${bakerDir}" --addr localhost --port ${toString (8732 + index)} \
+  run
+''

--- a/modules/tezos-baker.sh.nix
+++ b/modules/tezos-baker.sh.nix
@@ -1,0 +1,15 @@
+{ bakerAddressAlias
+, bakerDir
+, configDir
+, index
+, kit
+}:
+
+''
+set -e
+set -u
+set -o pipefail
+
+exec ${kit}/bin/tezos-baker-002-PsYLVpVv --base-dir "${bakerDir}" --addr localhost --port ${toString (8732 + index)} \
+  run with local node "${configDir}" "${bakerAddressAlias}"
+''

--- a/modules/tezos-endorser.sh.nix
+++ b/modules/tezos-endorser.sh.nix
@@ -1,0 +1,14 @@
+{ bakerAddressAlias
+, bakerDir
+, index
+, kit
+}:
+
+''
+set -e
+set -u
+set -o pipefail
+
+exec ${kit}/bin/tezos-endorser-002-PsYLVpVv --base-dir "${bakerDir}" --addr localhost --port ${toString (8732 + index)} \
+  run "${bakerAddressAlias}"
+''

--- a/modules/tezos-init.sh.nix
+++ b/modules/tezos-init.sh.nix
@@ -1,4 +1,7 @@
-{ configDir
+{ bakerAddressAlias
+, bakerDir
+, baking
+, configDir
 , kit
 , runit
 , user
@@ -9,9 +12,21 @@ set -e
 set -u
 set -o pipefail
 
+export TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=y
+
 mkdir -p "${configDir}"
 chown -R "${user}": "${configDir}"
 chmod 700 "${configDir}"
+
+${if baking then ''
+  mkdir -p "${bakerDir}"
+  chown -R "${user}": "${bakerDir}"
+  chmod 700 "${bakerDir}"
+  if ! ${kit}/bin/tezos-client --base-dir "${bakerDir}" list known addresses | grep -E '^${bakerAddressAlias}: '; then
+    ${kit}/bin/tezos-client --base-dir "${bakerDir}" gen keys "${bakerAddressAlias}"
+    ${kit}/bin/tezos-client --base-dir "${bakerDir}" list known addresses | grep -E '^${bakerAddressAlias}: '
+  fi
+'' else ""}
 
 if [ -e "${configDir}/identity.json" ]; then exit 0; fi
 

--- a/stub-system/configuration.nix
+++ b/stub-system/configuration.nix
@@ -11,9 +11,10 @@ let inherit (import (import ../pins/nixpkgs) {}) lib; in
   boot.isContainer = true;
 
   services.tezos.nodes = [
-    ({ configDir = "/etc/nixos/secret/tezos-alphanet"; } //
+    (rec { configDir = "/etc/nixos/secret/tezos-alphanet"; bakerDir = "${configDir}/baker"; } //
       lib.optionalAttrs (pkgs != null) { inherit pkgs; })
-    ({ configDir = "/etc/nixos/secret/tezos-mainnet"; network = "mainnet"; } //
+    (rec { configDir = "/etc/nixos/secret/tezos-mainnet"; bakerDir = "${configDir}/baker";
+           network = "mainnet"; } //
       lib.optionalAttrs (pkgs != null) { inherit pkgs; })
   ];
 }


### PR DESCRIPTION


No service definitions for accuser, baker and endorser

Solution: Implement baker services.

If a node has `baking.enable = true` (the default):
 - Automatically create and alias implicit baker address.
 - Run accuser, baker and endorser services.

Issues:
 - Haven't verified that it actually bakes.
 - No monitoring
 - No account management to automatically pay delegators their share
 - No documentation