### PR TITLE
Problem: Services may start too fast

### DIFF
--- a/modules/monitor-bootstrapped.sh.nix
+++ b/modules/monitor-bootstrapped.sh.nix
@@ -1,0 +1,20 @@
+{ bakerDir
+, bash
+, gnugrep
+, index
+, kit
+}:
+
+''
+#!${bash}/bin/bash
+
+set -euo pipefail
+
+export TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER=y
+
+while true; do
+  ${kit}/bin/tezos-client --base-dir "${bakerDir}" --addr localhost --port ${toString (8732 + index)} \
+    rpc get /monitor/bootstrapped |& grep '"block"' && break
+  sleep 3
+done
+''


### PR DESCRIPTION
In particular when an unsynced node comes up, it may take some time
before RPC services become available. If the baker and other services
try to start during this window they will simply fail, and systemd
will not restart them.

If you set `Restart=always`, systemd will restart them 5 times,
then complain that they failed too fast, too often, and then refuse to
ever start them again. (Default limit is 5 restarts within 10
seconds.)

Same if you set a check in `ExecStartPre` and let it just fail.

Solution: Let ExecStartPre wait until the RPC service is available.

Closes #19

Also takes care of the case where you bring down the node for some
reason, then bring it back up.

The services will be in state `activating` until the RPC comes up,
then ExecStart will run, and the services will be `activated`.

It would be more systemd-idiomatic to set `RestartSec=3`, let
`ExecStartPre` fail and let systemd restart it forever, but that spams
the unit log with:

```
Oct 08 16:42:09 [ . . . ]: Starting Tezos alphanet baker...
Oct 08 16:42:09 [ . . . ]: tezos-alphanet-baker-0.service: Control process exited, code=exited status=1
Oct 08 16:42:09 [ . . . ]: tezos-alphanet-baker-0.service: Failed with result 'exit-code'.
Oct 08 16:42:09 [ . . . ]: Failed to start Tezos alphanet baker.
Oct 08 16:42:12 [ . . . ]: tezos-alphanet-baker-0.service: Service hold-off time over, scheduling restart.
Oct 08 16:42:12 [ . . . ]: tezos-alphanet-baker-0.service: Scheduled restart job, restart counter is at 2.
Oct 08 16:42:12 [ . . . ]: Stopped Tezos alphanet baker.
Oct 08 16:42:12 [ . . . ]: Starting Tezos alphanet baker...
```

It seems more informative to just let the service hang in `activating`
until the RPC is available.